### PR TITLE
Follow MouseEventInit namespace

### DIFF
--- a/test/features/create/Create.spec.js
+++ b/test/features/create/Create.spec.js
@@ -121,14 +121,13 @@ describe('modules/create - Create', () => {
             expect(factory.factory.constructor.name).toBe('DefaultFactory');
         });
 
-        // TODO #75
-        // it('should have a position', () => {
-        //     document.dispatchEvent(new MouseEvent('mousemove', {
-        //         pageX: 250,
-        //         pageY: 320,
-        //     }));
-        //     toolbox.activate('create');
-        // });
+        it('should have a position', () => {
+            document.dispatchEvent(new MouseEvent('mousemove', {
+                clientX: 250,
+                clientY: 320,
+            }));
+            toolbox.activate('create');
+        });
 
     });
 });

--- a/test/features/create/Create.spec.js
+++ b/test/features/create/Create.spec.js
@@ -122,10 +122,11 @@ describe('modules/create - Create', () => {
         });
 
         it('should have a position', () => {
-            document.dispatchEvent(new MouseEvent('mousemove', {
+            const position = JSON.parse(JSON.stringify({
                 clientX: 250,
                 clientY: 320,
             }));
+            document.dispatchEvent(new MouseEvent('mousemove', position));
             toolbox.activate('create');
         });
 


### PR DESCRIPTION
Closes #75 

## Describe your changes
- Changed pageX, pageY to clientX, clientY 
- Followed by the [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/MouseEvent) Interface
