### PR TITLE
Handle listeners on attach and detach for proper context switching

### DIFF
--- a/src/Modeler.js
+++ b/src/Modeler.js
@@ -11,7 +11,9 @@ import MetaShapeToolsModule from './features/meta-tools';
 
 export default class Modeler extends Viewer {
 
-    constructor (options = {}) {
+    constructor (options = { canvas: { } }) {
+        options.canvas.id = 'rnw-modeler';
+
         super(Object.assign({
             modules: [
                 BaseToolsModule,
@@ -26,6 +28,7 @@ export default class Modeler extends Viewer {
                 PreviewModule,
             ],
         }, options));
+
         const toolbox = this.get('toolbox');
         toolbox.setDefaultTool('pointer');
         toolbox.activate('pointer');

--- a/src/Simulator.js
+++ b/src/Simulator.js
@@ -8,7 +8,9 @@ import Viewer from './Viewer';
  */
 export default class Simulator extends Viewer {
 
-    constructor (options = {}) {
+    constructor (options = { canvas: { } }) {
+        options.canvas.id = 'rnw-simulator';
+
         super(Object.assign({
             modules: [
                 // MetaSimulatingModule,

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -41,6 +41,8 @@ export default class Viewer extends Diagram {
         parentNode.appendChild(this.container);
 
         this.get('canvas').resized();
+
+        this.fire('attached', { instance: this });
     }
 
     detach () {
@@ -51,6 +53,8 @@ export default class Viewer extends Diagram {
         }
 
         parentNode.removeChild(this.container);
+
+        this.fire('detached', { instance: this });
     }
 
     fire (eventName, payload, middleware) {

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -38,14 +38,18 @@ export default class Viewer extends Diagram {
     attachTo (parentNode) {
         this.detach();
 
+        this.fire('attach.before', { instance: this, parentNode });
+
         parentNode.appendChild(this.container);
 
         this.get('canvas').resized();
 
-        this.fire('attached', { instance: this });
+        this.fire('attach.after', { instance: this, parentNode });
     }
 
     detach () {
+        this.fire('detach.before', { instance: this });
+
         const parentNode = this.container.parentNode;
 
         if (!parentNode) {
@@ -54,7 +58,7 @@ export default class Viewer extends Diagram {
 
         parentNode.removeChild(this.container);
 
-        this.fire('detached', { instance: this });
+        this.fire('detach.after', { instance: this });
     }
 
     fire (eventName, payload, middleware) {

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -48,13 +48,13 @@ export default class Viewer extends Diagram {
     }
 
     detach () {
-        this.fire('detach.before', { instance: this });
-
         const parentNode = this.container.parentNode;
 
         if (!parentNode) {
             return;
         }
+
+        this.fire('detach.before', { instance: this });
 
         parentNode.removeChild(this.container);
 

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -12,13 +12,11 @@ import { Injector } from './core/Injector';
 
 export default class Viewer extends Diagram {
 
-    constructor (options = { modules: [ ] }) {
-        // Create new container
+    constructor (options = { modules: [ ], canvas: { } }) {
         const container = document.createElement('div');
+        container.id = options.canvas.id || 'rnw-viewer';
         container.className = 'rnw-container';
 
-        // Pass container through options
-        options.canvas = options.canvas || {};
         options.canvas.container = container;
 
         const injector = new Injector([
@@ -55,8 +53,8 @@ export default class Viewer extends Diagram {
         parentNode.removeChild(this.container);
     }
 
-    fire (eventName, context) {
-        return this.get('eventBus').fire(eventName, context);
+    fire (eventName, payload, middleware) {
+        this.get('eventBus').fire(eventName, payload, middleware);
     }
 
     on (eventName, callback) {

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -38,13 +38,13 @@ export default class Viewer extends Diagram {
     attachTo (parentNode) {
         this.detach();
 
-        this.fire('attach.before', { instance: this, parentNode });
+        this.fire('attach.start', { instance: this, parentNode });
 
         parentNode.appendChild(this.container);
 
         this.get('canvas').resized();
 
-        this.fire('attach.after', { instance: this, parentNode });
+        this.fire('attach.end', { instance: this, parentNode });
     }
 
     detach () {
@@ -54,11 +54,11 @@ export default class Viewer extends Diagram {
             return;
         }
 
-        this.fire('detach.before', { instance: this });
+        this.fire('detach.start', { instance: this });
 
         parentNode.removeChild(this.container);
 
-        this.fire('detach.after', { instance: this });
+        this.fire('detach.end', { instance: this });
     }
 
     fire (eventName, payload, middleware) {

--- a/src/core/toolbox/behaviors/AttachBehavior.js
+++ b/src/core/toolbox/behaviors/AttachBehavior.js
@@ -11,24 +11,7 @@ export class AttachBehavior extends Behavior {
     }
 
     after () {
-        event.bind(
-            document,
-            'mousedown',
-            this.toolbox.onMouseDown.bind(this.toolbox),
-            true
-        );
-        event.bind(
-            document,
-            'mousemove',
-            this.toolbox.onMouseMove.bind(this.toolbox),
-            true
-        );
-        event.bind(
-            document,
-            'mouseup',
-            this.toolbox.onMouseUp.bind(this.toolbox),
-            true
-        );
+        this.toolbox.bindListeners();
     }
 
 }

--- a/src/core/toolbox/behaviors/AttachBehavior.js
+++ b/src/core/toolbox/behaviors/AttachBehavior.js
@@ -1,0 +1,34 @@
+import { event } from 'min-dom';
+
+import { Behavior } from '../../eventBus/Behavior';
+
+
+export class AttachBehavior extends Behavior {
+
+    constructor (toolbox) {
+        super();
+        this.toolbox = toolbox;
+    }
+
+    after () {
+        event.bind(
+            document,
+            'mousedown',
+            this.toolbox.onMouseDown.bind(this.toolbox),
+            true
+        );
+        event.bind(
+            document,
+            'mousemove',
+            this.toolbox.onMouseMove.bind(this.toolbox),
+            true
+        );
+        event.bind(
+            document,
+            'mouseup',
+            this.toolbox.onMouseUp.bind(this.toolbox),
+            true
+        );
+    }
+
+}

--- a/src/core/toolbox/behaviors/AttachBehavior.js
+++ b/src/core/toolbox/behaviors/AttachBehavior.js
@@ -1,5 +1,3 @@
-import { event } from 'min-dom';
-
 import { Behavior } from '../../eventBus/Behavior';
 
 

--- a/src/core/toolbox/behaviors/DetachBehavior.js
+++ b/src/core/toolbox/behaviors/DetachBehavior.js
@@ -1,0 +1,20 @@
+import { event } from 'min-dom';
+
+import { Behavior } from '../../eventBus/Behavior';
+
+
+export class DetachBehavior extends Behavior {
+
+    constructor (toolbox) {
+        super();
+        this.toolbox = toolbox;
+    }
+
+    before () {
+        this.toolbox.activateDefault();
+        event.unbind(document, 'mousedown', this.toolbox.onMouseDown, true);
+        event.unbind(document, 'mousemove', this.toolbox.onMouseMove, true);
+        event.unbind(document, 'mouseup', this.toolbox.onMouseUp, true);
+    }
+
+}

--- a/src/core/toolbox/behaviors/DetachBehavior.js
+++ b/src/core/toolbox/behaviors/DetachBehavior.js
@@ -12,9 +12,7 @@ export class DetachBehavior extends Behavior {
 
     before () {
         this.toolbox.activateDefault();
-        event.unbind(document, 'mousedown', this.toolbox.onMouseDown, true);
-        event.unbind(document, 'mousemove', this.toolbox.onMouseMove, true);
-        event.unbind(document, 'mouseup', this.toolbox.onMouseUp, true);
+        this.toolbox.unbindListeners();
     }
 
 }

--- a/src/core/toolbox/behaviors/DetachBehavior.js
+++ b/src/core/toolbox/behaviors/DetachBehavior.js
@@ -1,5 +1,3 @@
-import { event } from 'min-dom';
-
 import { Behavior } from '../../eventBus/Behavior';
 
 

--- a/src/core/toolbox/index.js
+++ b/src/core/toolbox/index.js
@@ -1,4 +1,6 @@
 import { HoverBehavior } from './behaviors/HoverBehavior';
+import { AttachBehavior } from './behaviors/AttachBehavior';
+import { DetachBehavior } from './behaviors/DetachBehavior';
 import { OutBehavior } from './behaviors/OutBehavior';
 import { PreviousToolBehavior } from './behaviors/PreviousToolBehavior';
 import { SnappedBehavior } from './behaviors/SnappedBehavior';
@@ -16,6 +18,8 @@ export default {
         'toolbox',
     ],
     __behaviors__: [
+        [ 'attach', AttachBehavior ],
+        [ 'detach', DetachBehavior ],
         [ 'element.hover', HoverBehavior ],
         [ 'element.out', OutBehavior ],
         [ 'tool-manager.update', ToolManagerBehavior ],

--- a/src/core/toolbox/providers/Toolbox.js
+++ b/src/core/toolbox/providers/Toolbox.js
@@ -29,13 +29,10 @@ export class Toolbox {
         event.bind(document, 'mousedown', this.onMouseDown.bind(this), true);
         event.bind(document, 'mousemove', this.onMouseMove.bind(this), true);
         event.bind(document, 'mouseup', this.onMouseUp.bind(this), true);
-        if (this.defaultTool) {
-            this.activate(this.defaultTool);
-        }
     }
 
     beforeDetach () {
-        this.deactivate();
+        this.activateDefault();
         event.unbind(document, 'mousedown', this.onMouseDown, true);
         event.unbind(document, 'mousemove', this.onMouseMove, true);
         event.unbind(document, 'mouseup', this.onMouseUp, true);
@@ -70,16 +67,11 @@ export class Toolbox {
         return this.activeTool;
     }
 
-    deactivate () {
-        if (!this.activeTool) return;
-
-        this.previousTool = this.activeTool;
-
+    activateDefault () {
         this.mouseDown = false;
         this.mouseEvent = { };
 
-        this.activeTool.onDisable({});
-        this.activeTool = null;
+        this.activate(this.defaultTool);
     }
 
     activatePrevious (context) {

--- a/src/core/toolbox/providers/Toolbox.js
+++ b/src/core/toolbox/providers/Toolbox.js
@@ -20,6 +20,28 @@ export class Toolbox {
         this.mouseDown = false;
         this.mouseEvent = { };
         this.pos = { x: 0, y: 0 };
+
+        this.mouseDownListener = null;
+        this.mouseMoveListener = null;
+        this.mouseUpListener = null;
+    }
+
+    bindListeners () {
+        this.mouseDownListener = this.onMouseDown.bind(this);
+        this.mouseMoveListener = this.onMouseMove.bind(this);
+        this.mouseUpListener = this.onMouseUp.bind(this);
+        event.bind(document, 'mousedown', this.mouseDownListener, true);
+        event.bind(document, 'mousemove', this.mouseMoveListener, true);
+        event.bind(document, 'mouseup', this.mouseUpListener, true);
+    }
+
+    unbindListeners () {
+        event.unbind(document, 'mousedown', this.mouseDownListener, true);
+        event.unbind(document, 'mousemove', this.mouseMoveListener, true);
+        event.unbind(document, 'mouseup', this.mouseUpListener, true);
+        this.mouseDownListener = null;
+        this.mouseMoveListener = null;
+        this.mouseUpListener = null;
     }
 
     setDefaultTool (name) {

--- a/src/core/toolbox/providers/Toolbox.js
+++ b/src/core/toolbox/providers/Toolbox.js
@@ -29,6 +29,9 @@ export class Toolbox {
         event.bind(document, 'mousedown', this.onMouseDown.bind(this), true);
         event.bind(document, 'mousemove', this.onMouseMove.bind(this), true);
         event.bind(document, 'mouseup', this.onMouseUp.bind(this), true);
+        if (this.defaultTool) {
+            this.activate(this.defaultTool);
+        }
     }
 
     beforeDetach () {
@@ -103,7 +106,7 @@ export class Toolbox {
     }
 
     onMouseUp (event) {
-        if (!this.activeTool) return;
+        if (!this.activeTool || !this.mouseDown) return;
 
         this.mouseDown = false;
         this.mouseEvent = this.createMouseEvent(event);

--- a/src/core/toolbox/providers/Toolbox.js
+++ b/src/core/toolbox/providers/Toolbox.js
@@ -20,22 +20,6 @@ export class Toolbox {
         this.mouseDown = false;
         this.mouseEvent = { };
         this.pos = { x: 0, y: 0 };
-
-        eventBus.on('attach.after', () => this.afterAttach());
-        eventBus.on('detach.before', () => this.beforeDetach());
-    }
-
-    afterAttach () {
-        event.bind(document, 'mousedown', this.onMouseDown.bind(this), true);
-        event.bind(document, 'mousemove', this.onMouseMove.bind(this), true);
-        event.bind(document, 'mouseup', this.onMouseUp.bind(this), true);
-    }
-
-    beforeDetach () {
-        this.activateDefault();
-        event.unbind(document, 'mousedown', this.onMouseDown, true);
-        event.unbind(document, 'mousemove', this.onMouseMove, true);
-        event.unbind(document, 'mouseup', this.onMouseUp, true);
     }
 
     setDefaultTool (name) {
@@ -47,13 +31,13 @@ export class Toolbox {
         this.tools[name].type = name;
     }
 
-    activate (tool, context = {}) {
+    activate (name, context = {}) {
         if (this.activeTool) {
             this.activeTool.onDisable(context);
         }
 
         this.previousTool = this.activeTool;
-        this.activeTool = this.tools[tool];
+        this.activeTool = this.tools[name];
         this.activeContext = context;
         Object.assign(this.mouseEvent, context, {
             tool: this.activeTool,

--- a/src/core/toolbox/providers/Toolbox.js
+++ b/src/core/toolbox/providers/Toolbox.js
@@ -21,9 +21,21 @@ export class Toolbox {
         this.mouseEvent = { };
         this.pos = { x: 0, y: 0 };
 
+        eventBus.on('attach.after', () => this.afterAttach());
+        eventBus.on('detach.before', () => this.beforeDetach());
+    }
+
+    afterAttach () {
         event.bind(document, 'mousedown', this.onMouseDown.bind(this), true);
         event.bind(document, 'mousemove', this.onMouseMove.bind(this), true);
         event.bind(document, 'mouseup', this.onMouseUp.bind(this), true);
+    }
+
+    beforeDetach () {
+        this.deactivate();
+        event.unbind(document, 'mousedown', this.onMouseDown, true);
+        event.unbind(document, 'mousemove', this.onMouseMove, true);
+        event.unbind(document, 'mouseup', this.onMouseUp, true);
     }
 
     setDefaultTool (name) {
@@ -53,6 +65,18 @@ export class Toolbox {
             this.activeTool.onEnable(this.mouseEvent);
         }
         return this.activeTool;
+    }
+
+    deactivate () {
+        if (!this.activeTool) return;
+
+        this.previousTool = this.activeTool;
+
+        this.mouseDown = false;
+        this.mouseEvent = { };
+
+        this.activeTool.onDisable({});
+        this.activeTool = null;
     }
 
     activatePrevious (context) {

--- a/src/features/connect/tools/ConnectTool.js
+++ b/src/features/connect/tools/ConnectTool.js
@@ -14,6 +14,7 @@ export class ConnectTool extends Tool {
 
     onDisable (event) {
         this.eventBus.fire('factory.reset', event);
+        this.eventBus.fire('connect.preview.clear', event);
     }
 
     onEnable (event) {

--- a/src/features/create/behaviors/CreatePreviewBehavior.js
+++ b/src/features/create/behaviors/CreatePreviewBehavior.js
@@ -29,6 +29,7 @@ export class CreatePreviewBehavior extends Behavior {
     }
 
     clear (event) {
+        this.shape = null;
         this.eventBus.fire('preview.clear', event);
     }
 

--- a/src/features/create/tools/CreateTool.js
+++ b/src/features/create/tools/CreateTool.js
@@ -11,6 +11,7 @@ export class CreateTool extends Tool {
         this.eventBus.fire('factory.reset', event);
         this.eventBus.fire('create.cursor.unset', event);
         this.eventBus.fire('create.preview.clear', event);
+        this.eventBus.fire('create.marker.clear', event);
     }
 
     onEnable (event) {

--- a/src/features/create/tools/CreateTool.js
+++ b/src/features/create/tools/CreateTool.js
@@ -10,6 +10,7 @@ export class CreateTool extends Tool {
     onDisable (event) {
         this.eventBus.fire('factory.reset', event);
         this.eventBus.fire('create.cursor.unset', event);
+        this.eventBus.fire('create.preview.clear', event);
     }
 
     onEnable (event) {

--- a/src/features/import/providers/Importer.js
+++ b/src/features/import/providers/Importer.js
@@ -9,7 +9,7 @@ export class Importer {
 
     import (data) {
         this.verify(data);
-        this.parseElements(data.elements);
+        this.createElements(data.elements);
     }
 
     verify (data) {
@@ -18,7 +18,7 @@ export class Importer {
         }
     }
 
-    parseElements (elements) {
+    createElements (elements) {
         elements.forEach((element) => {
             switch (element.type) {
                 case 'shape':
@@ -45,7 +45,9 @@ export class Importer {
         const target = this.elementRegistry.get(element.targetId);
         element.source = source;
         element.target = target;
-        element.waypoints = this.layouter.layoutConnection(element);
+        if (!element.waypoints) {
+            element.waypoints = this.layouter.layoutConnection(element);
+        }
         this.canvas.addConnection(element, parent);
     }
 

--- a/src/features/pointer/tools/PointerTool.js
+++ b/src/features/pointer/tools/PointerTool.js
@@ -15,6 +15,7 @@ export class PointerTool extends Tool {
     onDisable (event) {
         this.eventBus.fire('selection.clear');
         this.eventBus.fire('preview.clear');
+        this.eventBus.fire('rubberBand.preview.clear');
     }
 
     onEnable (event) {

--- a/src/features/pointer/tools/PointerTool.js
+++ b/src/features/pointer/tools/PointerTool.js
@@ -14,6 +14,7 @@ export class PointerTool extends Tool {
 
     onDisable (event) {
         this.eventBus.fire('selection.clear');
+        this.eventBus.fire('preview.clear');
     }
 
     onEnable (event) {

--- a/test/core/toolbox/Toolbox.spec.js
+++ b/test/core/toolbox/Toolbox.spec.js
@@ -4,6 +4,8 @@ import { Tester } from '../../Tester';
 
 describe('core/toolbox - Toolbox', () => {
     let diagram;
+    let toolbox;
+    let state;
 
     class TestProvider {
 
@@ -13,7 +15,8 @@ describe('core/toolbox - Toolbox', () => {
     class TestTool extends Tool {
 
         constructor (state) {
-            super(); this.state = state;
+            super();
+            this.state = state;
         }
         onDisable (event) {
             this.state.enabled = false;
@@ -48,49 +51,73 @@ describe('core/toolbox - Toolbox', () => {
         });
     });
 
+    beforeEach(() => toolbox = diagram.get('toolbox'));
+
+    beforeEach(() => state = diagram.get('state'));
+
     it('should be defined', function () {
-        diagram.invoke(function (toolbox) {
-            expect(toolbox).toBeDefined();
-        });
+        expect(toolbox).toBeDefined();
     });
 
     it('should activate a tool', function () {
-        diagram.invoke(function (toolbox) {
-            toolbox.activate('test');
+        toolbox.activate('test');
 
-            expect(toolbox.activeTool.type).toEqual('test');
-        });
+        expect(toolbox.activeTool.type).toEqual('test');
     });
 
     it('should have enable behavior', function () {
-        diagram.invoke(function (toolbox, state) {
-            toolbox.activate('test');
+        toolbox.activate('test');
 
-            expect(state.enabled).toBe(true);
-        });
+        expect(state.enabled).toBe(true);
     });
 
     it('should disable behavior on enable other behavior', function () {
-        diagram.invoke(function (toolbox, state) {
-            toolbox.activate('test');
-            toolbox.activate('other');
+        toolbox.activate('test');
+        toolbox.activate('other');
 
-            expect(state.enabled).toBe(false);
-        });
+        expect(state.enabled).toBe(false);
+    });
+
+    it('should set and activate a default tool', function () {
+        toolbox.setDefaultTool('test');
+        toolbox.activateDefault();
+
+        expect(toolbox.activeTool.type).toEqual('test');
     });
 
     describe('Behavior', () => {
         let eventBus;
-        let state;
 
         beforeEach(() => eventBus = diagram.get('eventBus'));
-
-        beforeEach(() => state = diagram.get('state'));
 
         it('should activate tool', () => {
             eventBus.fire('toolbox.activate', { tool: 'test' });
 
             expect(state.enabled).toBe(true);
+        });
+
+        it('should bind dom events after attach', () => {
+            eventBus.fire('attach.end');
+
+            expect(toolbox.mouseDownListener).not.toBe(null);
+            expect(toolbox.mouseMoveListener).not.toBe(null);
+            expect(toolbox.mouseUpListener).not.toBe(null);
+        });
+
+        it('should unbind dom events before detach', () => {
+            eventBus.fire('detach.start');
+
+            expect(toolbox.mouseDownListener).toBe(null);
+            expect(toolbox.mouseMoveListener).toBe(null);
+            expect(toolbox.mouseUpListener).toBe(null);
+        });
+
+        it('should reset tool before detach', () => {
+            eventBus.fire('toolbox.activate', { tool: 'test' });
+
+            eventBus.fire('detach.start');
+
+            expect(state.enabled).toBe(false);
         });
     });
 });

--- a/test/features/layouter/Layouter.spec.js
+++ b/test/features/layouter/Layouter.spec.js
@@ -1,0 +1,52 @@
+import LayouterModule from '../../../src/features/layouter';
+import { Tester } from '../../Tester';
+
+
+describe('modules/layouter - Layouter', () => {
+    let diagram;
+    let layouter;
+    let elementFactory;
+    let canvas;
+    let shape1;
+    let shape2;
+    let connection1;
+
+    beforeEach(() => {
+        diagram = new Tester({ modules: [ LayouterModule ] });
+        layouter = diagram.get('layouter');
+        elementFactory = diagram.get('elementFactory');
+        canvas = diagram.get('canvas');
+
+        shape1 = elementFactory.createShape({
+            id: 'shape1', x: 100, y: 200, width: 300, height: 400,
+        });
+        shape2 = elementFactory.createShape({
+            id: 'shape2', x: 500, y: 200, width: 300, height: 400,
+        });
+
+        canvas.addShape(shape1);
+        canvas.addShape(shape2);
+    });
+
+    it('should be defined', () => {
+        expect(layouter).toBeDefined();
+    });
+
+    describe('Provider', () => {
+
+        it('should layout a connection', () => {
+            const connection1 = elementFactory.createConnection({
+                source: shape1, target: shape2,
+            });
+
+            connection1.waypoints = layouter.layoutConnection(connection1);
+
+            expect(connection1.waypoints[0].x).toBe(250);
+            expect(connection1.waypoints[0].y).toBe(400);
+            expect(connection1.waypoints[1].x).toBe(650);
+            expect(connection1.waypoints[1].y).toBe(400);
+        });
+
+    });
+
+});

--- a/test/features/layouter/Layouter.spec.js
+++ b/test/features/layouter/Layouter.spec.js
@@ -5,27 +5,15 @@ import { Tester } from '../../Tester';
 describe('modules/layouter - Layouter', () => {
     let diagram;
     let layouter;
-    let elementFactory;
+    let defaultFactory;
     let canvas;
-    let shape1;
-    let shape2;
-    let connection1;
 
     beforeEach(() => {
         diagram = new Tester({ modules: [ LayouterModule ] });
+
         layouter = diagram.get('layouter');
-        elementFactory = diagram.get('elementFactory');
+        defaultFactory = diagram.get('defaultFactory');
         canvas = diagram.get('canvas');
-
-        shape1 = elementFactory.createShape({
-            id: 'shape1', x: 100, y: 200, width: 300, height: 400,
-        });
-        shape2 = elementFactory.createShape({
-            id: 'shape2', x: 500, y: 200, width: 300, height: 400,
-        });
-
-        canvas.addShape(shape1);
-        canvas.addShape(shape2);
     });
 
     it('should be defined', () => {
@@ -35,16 +23,30 @@ describe('modules/layouter - Layouter', () => {
     describe('Provider', () => {
 
         it('should layout a connection', () => {
-            const connection1 = elementFactory.createConnection({
+            const shape1 = defaultFactory.createShape({
+                id: 'shape1',
+                x: 100,
+                y: 200,
+            });
+            const shape2 = defaultFactory.createShape({
+                id: 'shape2',
+                x: 200,
+                y: 300,
+            });
+
+            canvas.addShape(shape1);
+            canvas.addShape(shape2);
+
+            const connection1 = defaultFactory.createConnection({
                 source: shape1, target: shape2,
             });
 
             connection1.waypoints = layouter.layoutConnection(connection1);
 
-            expect(connection1.waypoints[0].x).toBe(250);
-            expect(connection1.waypoints[0].y).toBe(400);
-            expect(connection1.waypoints[1].x).toBe(650);
-            expect(connection1.waypoints[1].y).toBe(400);
+            expect(connection1.waypoints[0].x).toBe(139);
+            expect(connection1.waypoints[0].y).toBe(231);
+            expect(connection1.waypoints[1].x).toBe(209);
+            expect(connection1.waypoints[1].y).toBe(301);
         });
 
     });

--- a/test/util/TestPlugin.js
+++ b/test/util/TestPlugin.js
@@ -30,7 +30,7 @@ export class TestPlugin extends Formalism.Plugin {
         });
     }
 
-    getStyleSheet () {
+    getStylesheet () {
         return Formalism.Ontology.Stylesheet.fromJson({
             'classifier-styles': [
                 {
@@ -56,6 +56,8 @@ export class TestPlugin extends Formalism.Plugin {
                     'line-style': 'normal-line',
                 },
             ],
+            'arrow-head-styles': [],
+            'text-styles': [],
         });
     }
 


### PR DESCRIPTION
Closes #79 

## Describe your changes
The main thing I did was adding the ability remove the event listeners bound to the document by the Toolbox before the instance gets detached and to rebind them after reattach.

The second step was to activate the default tool before the detach. This way, the current tool gets disabled (`onDisable()` is called). In all tool modules that use a preview, I added events to `onDisable()` to clear the various previews.

The main effect is, than no more `NS_ERROR_FAILURE`s occur after detaching the instance.

The second effect is, that you can now arbitrarily deactivate tools, even while an operation is in progress.