### PR TITLE
Keyboard events

### DIFF
--- a/src/Modeler.js
+++ b/src/Modeler.js
@@ -3,6 +3,7 @@ import OriginModule from 'diagram-js-origin';
 import ResizeModule from './features/resize';
 import PreviewModule from './features/preview';
 import SnappingModule from './features/snapping';
+import KeyboardEventsModule from './features/keyboard-events';
 
 import Viewer from './Viewer';
 import BaseToolsModule from './features/base-tools';
@@ -26,6 +27,7 @@ export default class Modeler extends Viewer {
                 OriginModule,
                 SnappingModule,
                 PreviewModule,
+                KeyboardEventsModule,
             ],
         }, options));
 

--- a/src/core/toolbox/behaviors/KeypressBehavior.js
+++ b/src/core/toolbox/behaviors/KeypressBehavior.js
@@ -1,0 +1,24 @@
+import { Behavior } from '../../eventBus/Behavior';
+
+
+export class KeypressBehavior extends Behavior {
+
+    constructor (toolbox) {
+        super();
+        this.toolbox = toolbox;
+    }
+
+    after (event) {
+        switch (event.originalEvent.key) {
+            case 'Esc': // IE/Edge specific value
+            case 'Escape':
+                this.toolbox.activateDefault();
+                break;
+            default:
+                return;
+        }
+
+        event.originalEvent.preventDefault();
+    }
+
+}

--- a/src/core/toolbox/index.js
+++ b/src/core/toolbox/index.js
@@ -2,6 +2,7 @@ import { HoverBehavior } from './behaviors/HoverBehavior';
 import { AttachBehavior } from './behaviors/AttachBehavior';
 import { DetachBehavior } from './behaviors/DetachBehavior';
 import { OutBehavior } from './behaviors/OutBehavior';
+import { KeypressBehavior } from './behaviors/KeypressBehavior';
 import { PreviousToolBehavior } from './behaviors/PreviousToolBehavior';
 import { SnappedBehavior } from './behaviors/SnappedBehavior';
 import { ToolboxActivateBehavior } from './behaviors/ToolboxActivateBehavior';
@@ -22,6 +23,7 @@ export default {
         [ 'detach', DetachBehavior ],
         [ 'element.hover', HoverBehavior ],
         [ 'element.out', OutBehavior ],
+        [ 'keypress', KeypressBehavior ],
         [ 'tool-manager.update', ToolManagerBehavior ],
         [ 'toolbox.previous', PreviousToolBehavior ],
         [ 'toolbox.activate', ToolboxActivateBehavior ],

--- a/src/features/keyboard-events/behaviors/AttachBehavior.js
+++ b/src/features/keyboard-events/behaviors/AttachBehavior.js
@@ -1,0 +1,15 @@
+import { Behavior } from '../../../core/eventBus/Behavior';
+
+
+export class AttachBehavior extends Behavior {
+
+    constructor (keyboardEvents) {
+        super();
+        this.keyboardEvents = keyboardEvents;
+    }
+
+    after () {
+        this.keyboardEvents.bindListeners();
+    }
+
+}

--- a/src/features/keyboard-events/behaviors/DetachBehavior.js
+++ b/src/features/keyboard-events/behaviors/DetachBehavior.js
@@ -1,0 +1,15 @@
+import { Behavior } from '../../../core/eventBus/Behavior';
+
+
+export class DetachBehavior extends Behavior {
+
+    constructor (keyboardEvents) {
+        super();
+        this.keyboardEvents = keyboardEvents;
+    }
+
+    before () {
+        this.keyboardEvents.unbindListeners();
+    }
+
+}

--- a/src/features/keyboard-events/index.js
+++ b/src/features/keyboard-events/index.js
@@ -1,0 +1,16 @@
+import { AttachBehavior } from './behaviors/AttachBehavior';
+import { DetachBehavior } from './behaviors/DetachBehavior';
+import { KeyboardEvents } from './providers/KeyboardEvents';
+
+
+export default {
+    __depends__: [],
+    __init__: [
+        'keyboardEvents',
+    ],
+    __behaviors__: [
+        [ 'attach', AttachBehavior ],
+        [ 'detach', DetachBehavior ],
+    ],
+    keyboardEvents: [ 'type', KeyboardEvents ],
+};

--- a/src/features/keyboard-events/providers/KeyboardEvents.js
+++ b/src/features/keyboard-events/providers/KeyboardEvents.js
@@ -6,8 +6,6 @@ export class KeyboardEvents {
     constructor (eventBus) {
         this.eventBus = eventBus;
 
-        this.keyDown = null;
-
         this.keyDownListener = null;
         this.keyUpListener = null;
     }
@@ -31,15 +29,11 @@ export class KeyboardEvents {
     onKeyDown (event) {
         if (event.defaultPrevented) return;
 
-        this.keyDown = event;
         this.eventBus.fire('keypress.start', { originalEvent: event });
     }
 
     onKeyUp (event) {
-        if (!this.keyDown) return;
-
         this.eventBus.fire('keypress.end', { originalEvent: event });
-        this.keyDown = null;
     }
 
 }

--- a/src/features/keyboard-events/providers/KeyboardEvents.js
+++ b/src/features/keyboard-events/providers/KeyboardEvents.js
@@ -1,0 +1,45 @@
+import { event } from 'min-dom';
+
+
+export class KeyboardEvents {
+
+    constructor (eventBus) {
+        this.eventBus = eventBus;
+
+        this.keyDown = null;
+
+        this.keyDownListener = null;
+        this.keyUpListener = null;
+    }
+
+    bindListeners () {
+        this.keyDownListener = this.onKeyDown.bind(this);
+        this.keyUpListener = this.onKeyUp.bind(this);
+
+        event.bind(document, 'keydown', this.keyDownListener, true);
+        event.bind(document, 'keyup', this.keyUpListener, true);
+    }
+
+    unbindListeners () {
+        event.unbind(document, 'keydown', this.keyDownListener, true);
+        event.unbind(document, 'keyup', this.keyUpListener, true);
+
+        this.keyDownListener = null;
+        this.keyUpListener = null;
+    }
+
+    onKeyDown (event) {
+        if (event.defaultPrevented) return;
+
+        this.keyDown = event;
+        this.eventBus.fire('keypress.start', { originalEvent: event });
+    }
+
+    onKeyUp (event) {
+        if (!this.keyDown) return;
+
+        this.eventBus.fire('keypress.end', { originalEvent: event });
+        this.keyDown = null;
+    }
+
+}

--- a/src/features/remove/behaviors/KeypressBehavior.js
+++ b/src/features/remove/behaviors/KeypressBehavior.js
@@ -12,8 +12,6 @@ export class KeypressBehavior extends Behavior {
     }
 
     after (event) {
-        let elements;
-
         switch (event.originalEvent.key) {
             case 'Delete':
             case 'Backspace':

--- a/src/features/remove/behaviors/KeypressBehavior.js
+++ b/src/features/remove/behaviors/KeypressBehavior.js
@@ -1,0 +1,32 @@
+import cloneDeep from 'lodash/cloneDeep';
+
+import { Behavior } from '../../../core/eventBus/Behavior';
+
+
+export class KeypressBehavior extends Behavior {
+
+    constructor (eventBus, selection) {
+        super();
+        this.eventBus = eventBus;
+        this.selection = selection;
+    }
+
+    after (event) {
+        let elements;
+
+        switch (event.originalEvent.key) {
+            case 'Delete':
+            case 'Backspace':
+                if (!this.selection.count()) return;
+                this.eventBus.fire('remove.elements', {
+                    elements: cloneDeep(this.selection.getAll()),
+                });
+                break;
+            default:
+                return;
+        }
+
+        event.originalEvent.preventDefault();
+    }
+
+}

--- a/src/features/remove/commands/RemoveElementsCommand.js
+++ b/src/features/remove/commands/RemoveElementsCommand.js
@@ -37,22 +37,24 @@ export class RemoveElementsCommand extends Command {
     }
 
     _removeConnection (element) {
-        element.source.incoming.splice(
-            element.source.incoming.indexOf(element),
-            1
-        );
-        element.source.outgoing.splice(
-            element.source.outgoing.indexOf(element),
-            1
-        );
-        element.target.incoming.splice(
-            element.target.incoming.indexOf(element),
-            1
-        );
-        element.target.outgoing.splice(
-            element.target.outgoing.indexOf(element),
-            1
-        );
+        const source = element.source || null;
+        const target = element.target || null;
+
+        if (source && source.incoming) {
+            source.incoming.splice(source.incoming.indexOf(element), 1);
+        }
+
+        if (source && source.outgoing) {
+            source.outgoing.splice(source.outgoing.indexOf(element), 1);
+        }
+
+        if (target && target.incoming) {
+            target.incoming.splice(target.incoming.indexOf(element), 1);
+        }
+
+        if (target &&target.outgoing) {
+            target.outgoing.splice(target.outgoing.indexOf(element), 1);
+        }
 
         this.canvas.removeConnection(element);
     }

--- a/src/features/remove/commands/RemoveElementsCommand.js
+++ b/src/features/remove/commands/RemoveElementsCommand.js
@@ -40,20 +40,24 @@ export class RemoveElementsCommand extends Command {
         const source = element.source || null;
         const target = element.target || null;
 
-        if (source && source.incoming) {
-            source.incoming.splice(source.incoming.indexOf(element), 1);
+        if (source) {
+            if (source.incoming) {
+                source.incoming.splice(source.incoming.indexOf(element), 1);
+            }
+
+            if (source.outgoing) {
+                source.outgoing.splice(source.outgoing.indexOf(element), 1);
+            }
         }
 
-        if (source && source.outgoing) {
-            source.outgoing.splice(source.outgoing.indexOf(element), 1);
-        }
+        if (target) {
+            if (target.incoming) {
+                target.incoming.splice(target.incoming.indexOf(element), 1);
+            }
 
-        if (target && target.incoming) {
-            target.incoming.splice(target.incoming.indexOf(element), 1);
-        }
-
-        if (target &&target.outgoing) {
-            target.outgoing.splice(target.outgoing.indexOf(element), 1);
+            if (target.outgoing) {
+                target.outgoing.splice(target.outgoing.indexOf(element), 1);
+            }
         }
 
         this.canvas.removeConnection(element);

--- a/src/features/remove/index.js
+++ b/src/features/remove/index.js
@@ -1,3 +1,6 @@
+import SelectionModule from '../selection';
+
+import { KeypressBehavior } from './behaviors/KeypressBehavior';
 import { RemoveElementsBehavior } from './behaviors/RemoveElementsBehavior';
 import { RemoveElementsCommand } from './commands/RemoveElementsCommand';
 import { RemoveProvider } from './providers/RemoveProvider';
@@ -5,11 +8,13 @@ import { RemoveProvider } from './providers/RemoveProvider';
 
 export default {
     __depends__: [
+        SelectionModule,
     ],
     __init__: [
         'remove',
     ],
     __behaviors__: [
+        [ 'keypress', KeypressBehavior ],
         [ 'remove.elements', RemoveElementsBehavior ],
     ],
     __commands__: [

--- a/src/features/selection/providers/SelectionProvider.js
+++ b/src/features/selection/providers/SelectionProvider.js
@@ -7,6 +7,10 @@ export class SelectionProvider extends Selection {
         super(eventBus);
     }
 
+    getAll () {
+        return this._selectedElements;
+    }
+
     clear () {
         this.select(null);
         this._selectedElements = [];

--- a/test/features/keyboard-events/KeyboardEvents.spec.js
+++ b/test/features/keyboard-events/KeyboardEvents.spec.js
@@ -18,46 +18,48 @@ describe('modules/keyboard-events - KeyboardEvents', () => {
     });
 
     describe('Provider', () => {
-        let fired;
+        let keyDownFired;
+        let keyUpFired;
+        let onKeyDown;
+        let onKeyUp;
 
         beforeEach(() => {
             keyboardEvents.bindListeners();
-            fired = false;
+            keyDownFired = false;
+            keyUpFired = false;
+            onKeyDown = () => keyDownFired = true;
+            onKeyUp = () => keyUpFired = true;
+            eventBus.on('keypress.start', onKeyDown);
+            eventBus.on('keypress.end', onKeyUp);
+        });
+
+        afterEach(() => {
+            keyboardEvents.unbindListeners();
+            eventBus.off('keypress.start', onKeyDown);
+            eventBus.off('keypress.end', onKeyUp);
         });
 
         it('it should fire keypress.start on key down', () => {
-            eventBus.on('keypress.start', () => {
-                fired = true;
-            });
-
             const event = new KeyboardEvent('keydown');
             document.dispatchEvent(event);
 
-            expect(fired).toBe(true);
+            expect(keyDownFired).toBe(true);
         });
 
         it('it should fire keypress.end on key up', () => {
-            eventBus.on('keypress.end', () => {
-                fired = true;
-            });
-
             const event = new KeyboardEvent('keyup');
             document.dispatchEvent(event);
 
-            expect(fired).toBe(true);
+            expect(keyUpFired).toBe(true);
         });
 
         it('it should not fire keypress.start if default was prevented', () => {
-            eventBus.on('keypress.start', () => {
-                fired = true;
-            });
-
             const event = new KeyboardEvent('keydown');
             event.preventDefault();
             event.stopPropagation();
             document.dispatchEvent(event);
 
-            expect(fired).toBe(false);
+            expect(keyDownFired).toBe(false);
         });
 
     });

--- a/test/features/keyboard-events/KeyboardEvents.spec.js
+++ b/test/features/keyboard-events/KeyboardEvents.spec.js
@@ -1,0 +1,82 @@
+import KeyboardEventsModule from '../../../src/features/keyboard-events';
+import { Tester } from '../../Tester';
+
+
+describe('modules/keyboard-events - KeyboardEvents', () => {
+    let diagram;
+    let keyboardEvents;
+    let eventBus;
+
+    beforeEach(() => {
+        diagram = new Tester({ modules: [ KeyboardEventsModule ] });
+        keyboardEvents = diagram.get('keyboardEvents');
+        eventBus = diagram.get('eventBus');
+    });
+
+    it('should be defined', () => {
+        expect(keyboardEvents).toBeDefined();
+    });
+
+    describe('Provider', () => {
+        let fired;
+
+        beforeEach(() => {
+            keyboardEvents.bindListeners();
+            fired = false;
+        });
+
+        it('it should fire keypress.start on key down', () => {
+            eventBus.on('keypress.start', (context) => {
+                fired = true;
+            });
+
+            const event = new KeyboardEvent('keydown');
+            document.dispatchEvent(event);
+
+            expect(fired).toBe(true);
+        });
+
+        it('it should fire keypress.end on key up', () => {
+            eventBus.on('keypress.end', (context) => {
+                fired = true;
+            });
+
+            const event = new KeyboardEvent('keyup');
+            document.dispatchEvent(event);
+
+            expect(fired).toBe(true);
+        });
+
+        it('it should not fire keypress.start if default was prevented', () => {
+            eventBus.on('keypress.start', (context) => {
+                fired = true;
+            });
+
+            const event = new KeyboardEvent('keydown');
+            event.preventDefault();
+            document.dispatchEvent(event);
+
+            expect(fired).toBe(true);
+        });
+
+    });
+
+    describe('Behavior', () => {
+
+        it('should bind dom events after attach', () => {
+            eventBus.fire('attach.end');
+
+            expect(keyboardEvents.keyDownListener).not.toBe(null);
+            expect(keyboardEvents.keyUpListener).not.toBe(null);
+        });
+
+        it('should unbind dom events before detach', () => {
+            eventBus.fire('detach.start');
+
+            expect(keyboardEvents.keyDownListener).toBe(null);
+            expect(keyboardEvents.keyUpListener).toBe(null);
+        });
+
+    });
+
+});

--- a/test/features/keyboard-events/KeyboardEvents.spec.js
+++ b/test/features/keyboard-events/KeyboardEvents.spec.js
@@ -26,7 +26,7 @@ describe('modules/keyboard-events - KeyboardEvents', () => {
         });
 
         it('it should fire keypress.start on key down', () => {
-            eventBus.on('keypress.start', (context) => {
+            eventBus.on('keypress.start', () => {
                 fired = true;
             });
 
@@ -37,7 +37,7 @@ describe('modules/keyboard-events - KeyboardEvents', () => {
         });
 
         it('it should fire keypress.end on key up', () => {
-            eventBus.on('keypress.end', (context) => {
+            eventBus.on('keypress.end', () => {
                 fired = true;
             });
 
@@ -48,15 +48,16 @@ describe('modules/keyboard-events - KeyboardEvents', () => {
         });
 
         it('it should not fire keypress.start if default was prevented', () => {
-            eventBus.on('keypress.start', (context) => {
+            eventBus.on('keypress.start', () => {
                 fired = true;
             });
 
             const event = new KeyboardEvent('keydown');
             event.preventDefault();
+            event.stopPropagation();
             document.dispatchEvent(event);
 
-            expect(fired).toBe(true);
+            expect(fired).toBe(false);
         });
 
     });


### PR DESCRIPTION
Closes #81

## Describe your changes
I added a new module KeyboardEvents that add listeners for keyup and keydown that propagate events to the EventBus.
I then added behaviors to the Toolbox and Remove modules for these events.
I decided not to use the diagram-js keyboard module for this because it is to extensive and does not use our concept of behaviors.