### PR TITLE
Restore resize

### DIFF
--- a/src/features/cursor/behaviors/CursorSetBehavior.js
+++ b/src/features/cursor/behaviors/CursorSetBehavior.js
@@ -20,4 +20,12 @@ export class CursorSetBehavior extends Behavior {
         this.cursor.set('grabbing');
     }
 
+    nwse (event) {
+        this.cursor.set('nwse-resize');
+    }
+
+    nesw (event) {
+        this.cursor.set('nesw-resize');
+    }
+
 }

--- a/src/features/handle/providers/HandleFactory.js
+++ b/src/features/handle/providers/HandleFactory.js
@@ -1,3 +1,4 @@
+import { uid } from '../../../core/util/Uid';
 import { ElementFactory } from '../../factory/providers/ElementFactory';
 
 
@@ -9,6 +10,7 @@ export class HandleFactory extends ElementFactory {
 
     createShape (attributes = {}) {
         return super.createShape(Object.assign({
+            id: uid('handle'),
             type: 'handle',
             metaObject: {
                 representation: {

--- a/src/features/handle/providers/HandleProvider.js
+++ b/src/features/handle/providers/HandleProvider.js
@@ -13,11 +13,13 @@ export class HandleProvider {
         const position = handle.orientation.position();
         handle.x = position.x - Math.round(handle.width / 2);
         handle.y = position.y - Math.round(handle.height / 2);
+        handle.visible = true;
         this.canvas.addShape(handle);
     }
 
     hide (handle) {
         this.canvas.removeShape(handle);
+        handle.visible = false;
     }
 
 }

--- a/src/features/handle/providers/HandleProvider.js
+++ b/src/features/handle/providers/HandleProvider.js
@@ -5,8 +5,11 @@ export class HandleProvider {
         this.canvas = canvas;
     }
 
-    create (orientation) {
-        return this.factory.createShape({ orientation });
+    create (orientation, attributes) {
+        return this.factory.createShape(Object.assign({},
+            { orientation },
+            attributes
+        ));
     }
 
     show (handle) {

--- a/src/features/pointer/index.js
+++ b/src/features/pointer/index.js
@@ -1,6 +1,7 @@
 import SelectionModule from '../selection';
 import RubberBandModule from '../rubber-band';
 import MoveModule from '../move';
+import CursorModule from '../cursor';
 
 import { SelectBehavior } from './behaviors/SelectBehavior';
 import { PointerProvider } from './providers/PointerProvider';
@@ -9,6 +10,7 @@ import { PointerTool } from './tools/PointerTool';
 
 export default {
     __depends__: [
+        CursorModule,
         SelectionModule,
         RubberBandModule,
         MoveModule,

--- a/src/features/pointer/tools/PointerTool.js
+++ b/src/features/pointer/tools/PointerTool.js
@@ -83,6 +83,7 @@ export class PointerTool extends Tool {
             this.eventBus.fire('rubberBand.preview.clear', event);
             this.isSelecting = false;
         } else if (this.isResizing) {
+            this.eventBus.fire('cursor.unset');
             this.isResizing = false;
         }
     }

--- a/src/features/pointer/tools/PointerTool.js
+++ b/src/features/pointer/tools/PointerTool.js
@@ -1,4 +1,5 @@
 import { Tool } from '../../../core/toolbox/Tool';
+import { CardinalOrientation } from '../../orientation/CardinalOrientation';
 
 
 export class PointerTool extends Tool {
@@ -11,6 +12,7 @@ export class PointerTool extends Tool {
 
         this.isSelecting = false;
         this.isMoving = false;
+        this.isResizing = false;
     }
 
     onDisable (event) {
@@ -23,17 +25,22 @@ export class PointerTool extends Tool {
     }
 
     onMouseDown (event) {
-        if (event.hover) {
-            this.eventBus.fire('pointer.select', event);
-        }
-        event.elements = this.selection.get();
-        if (event.hover) {
-            if (event.rootStart) {
-                this.isSelecting = true;
-            } else {
-                this.eventBus.fire('move.preview.init', event);
-                this.isMoving = true;
+        if (event.hover && event.hover.type === 'handle') {
+            this.isResizing = event.hover.orientation.direction;
+        } else {
+            if (event.hover) {
+                this.eventBus.fire('pointer.select', event);
             }
+            event.elements = this.selection.get();
+            if (event.hover) {
+                if (event.rootStart) {
+                    this.isSelecting = true;
+                } else {
+                    this.eventBus.fire('move.preview.init', event);
+                    this.isMoving = true;
+                }
+            }
+
         }
     }
 
@@ -45,6 +52,21 @@ export class PointerTool extends Tool {
                 this.eventBus.fire('preview.move', event);
             } else if (this.isSelecting) {
                 this.eventBus.fire('rubberBand.preview', event);
+            } else if (this.isResizing) {
+                switch (this.isResizing) {
+                    case CardinalOrientation.NORTH_WEST:
+                        console.log('resize NORTH_WEST');
+                        break;
+                    case CardinalOrientation.NORTH_EAST:
+                        console.log('resize NORTH_EAST');
+                        break;
+                    case CardinalOrientation.SOUTH_EAST:
+                        console.log('resize SOUTH_EAST');
+                        break;
+                    case CardinalOrientation.SOUTH_WEST:
+                        console.log('resize SOUTH_WEST');
+                        break;
+                }
             }
         }
     }
@@ -60,12 +82,52 @@ export class PointerTool extends Tool {
             this.eventBus.fire('rubberBand.select', event);
             this.eventBus.fire('rubberBand.preview.clear', event);
             this.isSelecting = false;
+        } else if (this.isResizing) {
+            this.isResizing = false;
         }
     }
 
     onDoubleClick (event) {
         if (event.hover.type === 'label') {
             this.toolbox.activate('edit', { label: event.hover });
+        }
+    }
+
+    onHover (event) {
+        if (event.element && event.element.type === 'handle') {
+            switch (event.element.orientation.direction) {
+                case CardinalOrientation.NORTH_WEST:
+                    this.eventBus.fire('cursor.set.nwse');
+                    break;
+                case CardinalOrientation.NORTH_EAST:
+                    this.eventBus.fire('cursor.set.nesw');
+                    break;
+                case CardinalOrientation.SOUTH_EAST:
+                    this.eventBus.fire('cursor.set.nwse');
+                    break;
+                case CardinalOrientation.SOUTH_WEST:
+                    this.eventBus.fire('cursor.set.nesw');
+                    break;
+            }
+        }
+    }
+
+    onOut (event) {
+        if (event.element && event.element.type === 'handle') {
+            switch (event.element.orientation.direction) {
+                case CardinalOrientation.NORTH_WEST:
+                    this.eventBus.fire('cursor.unset');
+                    break;
+                case CardinalOrientation.NORTH_EAST:
+                    this.eventBus.fire('cursor.unset');
+                    break;
+                case CardinalOrientation.SOUTH_EAST:
+                    this.eventBus.fire('cursor.unset');
+                    break;
+                case CardinalOrientation.SOUTH_WEST:
+                    this.eventBus.fire('cursor.unset');
+                    break;
+            }
         }
     }
 

--- a/src/features/pointer/tools/PointerTool.js
+++ b/src/features/pointer/tools/PointerTool.js
@@ -94,6 +94,8 @@ export class PointerTool extends Tool {
     }
 
     onHover (event) {
+        if (this.isResizing) return;
+
         if (event.element && event.element.type === 'handle') {
             switch (event.element.orientation.direction) {
                 case CardinalOrientation.NORTH_WEST:
@@ -113,6 +115,8 @@ export class PointerTool extends Tool {
     }
 
     onOut (event) {
+        if (this.isResizing) return;
+
         if (event.element && event.element.type === 'handle') {
             switch (event.element.orientation.direction) {
                 case CardinalOrientation.NORTH_WEST:

--- a/src/features/pointer/tools/PointerTool.js
+++ b/src/features/pointer/tools/PointerTool.js
@@ -83,7 +83,7 @@ export class PointerTool extends Tool {
             this.eventBus.fire('rubberBand.preview.clear', event);
             this.isSelecting = false;
         } else if (this.isResizing) {
-            this.eventBus.fire('cursor.unset');
+            this.handleResizeCursor(event.hover);
             this.isResizing = false;
         }
     }
@@ -96,9 +96,12 @@ export class PointerTool extends Tool {
 
     onHover (event) {
         if (this.isResizing) return;
+        this.handleResizeCursor(event.element);
+    }
 
-        if (event.element && event.element.type === 'handle') {
-            switch (event.element.orientation.direction) {
+    handleResizeCursor (element) {
+        if (element && element.type === 'handle') {
+            switch (element.orientation.direction) {
                 case CardinalOrientation.NORTH_WEST:
                     this.eventBus.fire('cursor.set.nwse');
                     break;
@@ -112,6 +115,8 @@ export class PointerTool extends Tool {
                     this.eventBus.fire('cursor.set.nesw');
                     break;
             }
+        } else {
+            this.eventBus.fire('cursor.unset');
         }
     }
 

--- a/src/features/pointer/tools/PointerTool.js
+++ b/src/features/pointer/tools/PointerTool.js
@@ -55,16 +55,16 @@ export class PointerTool extends Tool {
             } else if (this.isResizing) {
                 switch (this.isResizing) {
                     case CardinalOrientation.NORTH_WEST:
-                        console.log('resize NORTH_WEST');
+                        this.eventBus.fire('resize.element.nw', event, true);
                         break;
                     case CardinalOrientation.NORTH_EAST:
-                        console.log('resize NORTH_EAST');
+                        this.eventBus.fire('resize.element.ne', event, true);
                         break;
                     case CardinalOrientation.SOUTH_EAST:
-                        console.log('resize SOUTH_EAST');
+                        this.eventBus.fire('resize.element.se', event, true);
                         break;
                     case CardinalOrientation.SOUTH_WEST:
-                        console.log('resize SOUTH_WEST');
+                        this.eventBus.fire('resize.element.sw', event, true);
                         break;
                 }
             }

--- a/src/features/resize/behaviors/ResizeElementBehavior.js
+++ b/src/features/resize/behaviors/ResizeElementBehavior.js
@@ -11,6 +11,10 @@ export class ResizeElementBehavior extends Behavior {
         this.graphicsFactory = graphicsFactory;
     }
 
+    init (event) {
+        this.resize.init(event.element.x, event.element.y);
+    }
+
     nw (event) {
         const element = event.element || event.elements[0];
         this.resize.element(element).dimension(

--- a/src/features/resize/behaviors/ResizeElementBehavior.js
+++ b/src/features/resize/behaviors/ResizeElementBehavior.js
@@ -1,21 +1,61 @@
 import { Behavior } from '../../../core/eventBus/Behavior';
 
-/**
- * Resize any shape and path relative to initial state
- */
-export class ResizeBehavior extends Behavior {
 
-    constructor (eventBus) {
+export class ResizeElementBehavior extends Behavior {
+
+    constructor (eventBus, resize, elementRegistry, graphicsFactory) {
         super();
         this.eventBus = eventBus;
+        this.resize = resize;
+        this.elementRegistry = elementRegistry;
+        this.graphicsFactory = graphicsFactory;
     }
 
-    during (event) {
-        console.log(event);
+    nw (event) {
+        const element = event.element || event.elements[0];
+        this.resize.element(element).dimension(
+            element.x,
+            element.y,
+            Math.abs(event.x - element.x),
+            Math.abs(event.y - element.y)
+        );
+    }
 
-        const shape = event.shape.businessObject;
+    ne (event) {
+        const element = event.element || event.elements[0];
+        this.resize.element(element).dimension(
+            element.x,
+            element.y,
+            Math.abs(event.x - element.x),
+            Math.abs(event.y - element.y)
+        );
+    }
 
-        const bounds = event.context.newBounds;
+    sw (event) {
+        const element = event.element || event.elements[0];
+        this.resize.element(element).dimension(
+            element.x,
+            element.y,
+            Math.abs(event.x - element.x),
+            Math.abs(event.y - element.y)
+        );
+    }
+
+    se (event) {
+        const element = event.element || event.elements[0];
+        this.resize.element(element).dimension(
+            element.x,
+            element.y,
+            Math.abs(event.x - element.x),
+            Math.abs(event.y - element.y)
+        );
+    }
+
+    after (event) {
+        const element = event.element || event.elements[0];
+        const shape = element.metaObject;
+
+        const bounds = element;
         const proportions = shape.representation.proportions;
 
         if (!proportions) return;
@@ -62,6 +102,18 @@ export class ResizeBehavior extends Behavior {
                 }
                 shape.representation.attributes.points = points.join(' ');
         }
+
+        this._updateGraphics(element, 'shape');
+    }
+
+    _updateGraphics (element, type) {
+        const gfx = this.elementRegistry.getGraphics(element.id);
+        const event = { elements: [ element ], element: element, gfx: gfx };
+
+        this.graphicsFactory.update(type || element.type, element, gfx);
+        this.eventBus.fire(element.type + '.changed', event);
+        this.eventBus.fire('elements.changed', event);
+        this.eventBus.fire('element.changed', event);
     }
 
 }

--- a/src/features/resize/behaviors/ResizeElementBehavior.js
+++ b/src/features/resize/behaviors/ResizeElementBehavior.js
@@ -15,43 +15,13 @@ export class ResizeElementBehavior extends Behavior {
         this.resize.init(event.element.x, event.element.y);
     }
 
-    nw (event) {
-        const element = event.element || event.elements[0];
-        this.resize.element(element).dimension(
-            element.x,
-            element.y,
-            Math.abs(event.x - element.x),
-            Math.abs(event.y - element.y)
-        );
-    }
-
-    ne (event) {
-        const element = event.element || event.elements[0];
-        this.resize.element(element).dimension(
-            element.x,
-            element.y,
-            Math.abs(event.x - element.x),
-            Math.abs(event.y - element.y)
-        );
-    }
-
-    sw (event) {
-        const element = event.element || event.elements[0];
-        this.resize.element(element).dimension(
-            element.x,
-            element.y,
-            Math.abs(event.x - element.x),
-            Math.abs(event.y - element.y)
-        );
-    }
-
     se (event) {
         const element = event.element || event.elements[0];
         this.resize.element(element).dimension(
             element.x,
             element.y,
-            Math.abs(event.x - element.x),
-            Math.abs(event.y - element.y)
+            Math.max(element.minWidth || 0, event.x - element.x),
+            Math.max(element.minHeight || 0, event.y - element.y)
         );
     }
 

--- a/src/features/resize/commands/ResizeElementCommand.js
+++ b/src/features/resize/commands/ResizeElementCommand.js
@@ -1,0 +1,16 @@
+import { Command } from '../../../core/command/Command';
+
+
+export class ResizeElementCommand extends Command {
+
+    constructor () {
+        super();
+    }
+
+    execute (context) {
+    }
+
+    revert (context) {
+    }
+
+}

--- a/src/features/resize/index.js
+++ b/src/features/resize/index.js
@@ -1,13 +1,20 @@
-import { ResizeBehavior } from './behavior/ResizeBehavior';
+import { ResizeElementBehavior } from './behaviors/ResizeElementBehavior';
+import { ResizeElementCommand } from './commands/ResizeElementCommand';
+import { ResizeProvider } from './providers/ResizeProvider';
 
 
 export default {
     __depends__: [
     ],
     __init__: [
-
+        'resize',
+    ],
+    __commands__: [
+        [ 'resize.element', ResizeElementCommand ],
     ],
     __behaviors__: [
-        [ 'resize.end', 1500, ResizeBehavior ],
+        [ 'resize.element', ResizeElementBehavior ],
     ],
+
+    resize: [ 'type', ResizeProvider ],
 };

--- a/src/features/resize/providers/ResizeProvider.js
+++ b/src/features/resize/providers/ResizeProvider.js
@@ -1,7 +1,12 @@
 export class ResizeProvider {
 
     constructor () {
+        this.position = { x: 0, y: 0 };
+    }
 
+    init (x, y) {
+        this.position.x = x;
+        this.position.y = y;
     }
 
     element (element) {

--- a/src/features/resize/providers/ResizeProvider.js
+++ b/src/features/resize/providers/ResizeProvider.js
@@ -1,0 +1,18 @@
+export class ResizeProvider {
+
+    constructor () {
+
+    }
+
+    element (element) {
+        return {
+            dimension: (x, y, width, height) => {
+                element.x = x;
+                element.y = y;
+                element.width = width;
+                element.height = height;
+            },
+        };
+    }
+
+}

--- a/src/features/selection/index.js
+++ b/src/features/selection/index.js
@@ -28,6 +28,7 @@ export default {
         [ 'shape.remove', SelectionRemoveBehavior ],
         [ 'connection.remove', SelectionRemoveBehavior ],
         [ 'move.elements', MoveElementsBehavior ],
+        [ 'resize.element', MoveElementsBehavior ],
     ],
     __commands__: [],
     __rules__: [],

--- a/src/features/selection/providers/SelectionHandlesProvider.js
+++ b/src/features/selection/providers/SelectionHandlesProvider.js
@@ -9,11 +9,40 @@ export class SelectionHandlesProvider {
 
     create (bbox) {
         const CardinalOrientation = this.orientation.orientation('cardinal');
+
+        const style = {
+            metaObject: {
+                representation: {
+                    name: 'rect',
+                    type: 'element',
+                    attributes: {
+                        x: 1,
+                        y: 1,
+                        width: 6,
+                        height: 6,
+                        style: 'fill:#fff;stroke:#ddd;stroke-width:2px;',
+                    },
+                    children: [],
+                },
+            },
+        };
         this.handles = [
-            this.handle.create(new CardinalOrientation(bbox, 'northwest')),
-            this.handle.create(new CardinalOrientation(bbox, 'northeast')),
-            this.handle.create(new CardinalOrientation(bbox, 'southeast')),
-            this.handle.create(new CardinalOrientation(bbox, 'southwest')),
+            this.handle.create(
+                new CardinalOrientation(bbox, 'northwest'),
+                style
+            ),
+            this.handle.create(
+                new CardinalOrientation(bbox, 'northeast'),
+                style
+            ),
+            this.handle.create(
+                new CardinalOrientation(bbox, 'southeast'),
+                style
+            ),
+            this.handle.create(
+                new CardinalOrientation(bbox, 'southwest'),
+                style
+            ),
         ];
     }
 

--- a/src/features/selection/providers/SelectionHandlesProvider.js
+++ b/src/features/selection/providers/SelectionHandlesProvider.js
@@ -27,6 +27,7 @@ export class SelectionHandlesProvider {
             },
         };
         this.handles = [
+            /*
             this.handle.create(
                 new CardinalOrientation(bbox, 'northwest'),
                 style
@@ -35,14 +36,17 @@ export class SelectionHandlesProvider {
                 new CardinalOrientation(bbox, 'northeast'),
                 style
             ),
+            */
             this.handle.create(
                 new CardinalOrientation(bbox, 'southeast'),
                 style
             ),
+            /*
             this.handle.create(
                 new CardinalOrientation(bbox, 'southwest'),
                 style
             ),
+            */
         ];
     }
 

--- a/src/features/selection/providers/SelectionProvider.js
+++ b/src/features/selection/providers/SelectionProvider.js
@@ -83,10 +83,10 @@ export class SelectionProvider extends Selection {
         this.selectionHandles.hide();
 
         const bbox = getBBox(this.get());
-        this.bbox.x = bbox.x;
-        this.bbox.y = bbox.y;
-        this.bbox.width = bbox.width;
-        this.bbox.height = bbox.height;
+        this.bbox.x = bbox.x - 6;
+        this.bbox.y = bbox.y - 6;
+        this.bbox.width = bbox.width + 12;
+        this.bbox.height = bbox.height + 12;
 
         if (!this.empty()) {
             this.selectionHandles.show();

--- a/test/features/cursor/Cursor.spec.js
+++ b/test/features/cursor/Cursor.spec.js
@@ -64,6 +64,18 @@ describe('modules/cursor - Cursor', () => {
             expect(document.body.style.cursor).toBe('grabbing');
         });
 
+        it('should set the cursor to nwse-resize', () => {
+            eventBus.fire('cursor.set.nwse');
+
+            expect(document.body.style.cursor).toBe('nwse-resize');
+        });
+
+        it('should set the cursor to nesw-resize', () => {
+            eventBus.fire('cursor.set.nesw');
+
+            expect(document.body.style.cursor).toBe('nesw-resize');
+        });
+
     });
 
 });

--- a/test/features/pointer/Pointer.spec.js
+++ b/test/features/pointer/Pointer.spec.js
@@ -1,3 +1,4 @@
+import { CardinalOrientation } from '../../../src/features/orientation/CardinalOrientation';
 import { Tester } from '../../Tester';
 import PointerModule from '../../../src/features/pointer';
 import EditModule from '../../../src/features/edit';
@@ -67,6 +68,34 @@ describe('modules/pointer - Pointer', () => {
             toolbox.activeTool.onMouseUp({});
 
             expect(document.body.style.cursor).toBe('default');
+        });
+
+        it('should not reset if the mouse is still over a handle', function () {
+            document.body.style.cursor = 'nesw-resize';
+
+            toolbox.activeTool.isResizing = true;
+            toolbox.activeTool.onMouseUp({
+                hover: {
+                    type: 'handle',
+                    orientation: { direction: CardinalOrientation.NORTH_EAST },
+                }
+            });
+
+            expect(document.body.style.cursor).toBe('nesw-resize');
+        });
+
+        it('should change the cursor if landed on other resize handle', function () {
+            document.body.style.cursor = 'nesw-resize';
+
+            toolbox.activeTool.isResizing = true;
+            toolbox.activeTool.onMouseUp({
+                hover: {
+                    type: 'handle',
+                    orientation: { direction: CardinalOrientation.SOUTH_EAST },
+                }
+            });
+
+            expect(document.body.style.cursor).toBe('nwse-resize');
         });
 
     });

--- a/test/features/pointer/Pointer.spec.js
+++ b/test/features/pointer/Pointer.spec.js
@@ -50,9 +50,6 @@ describe('modules/pointer - Pointer', () => {
             expect(toolbox.activeTool.type).toBe('edit');
         });
 
-        /**
-         * TODO: Must be changed in if has no primary label
-         */
         it('should not activate edit on doubleClick on label', function () {
             toolbox.onDoubleClick({ element: shape, originalEvent: { } });
 
@@ -61,6 +58,15 @@ describe('modules/pointer - Pointer', () => {
             toolbox.onDoubleClick({ element: connection, originalEvent: { } });
 
             expect(toolbox.activeTool.type).not.toBe('edit');
+        });
+
+        it('should reset the cursor after resize', function () {
+            document.body.style.cursor = 'nesw-resize';
+
+            toolbox.activeTool.isResizing = true;
+            toolbox.activeTool.onMouseUp({});
+
+            expect(document.body.style.cursor).toBe('default');
         });
 
     });

--- a/test/features/resize/Resize.spec.js
+++ b/test/features/resize/Resize.spec.js
@@ -30,6 +30,13 @@ describe('modules/resize - Resize', () => {
 
     describe('Provider', () => {
 
+        it('should init the resize', function () {
+            resize.init(50, 100);
+
+            expect(resize.position.x).toBe(50);
+            expect(resize.position.y).toBe(100);
+        });
+
         it('should resize a shape', () => {
             resize.element(shape_1).dimension(50, 100, 600, 550);
 
@@ -37,6 +44,22 @@ describe('modules/resize - Resize', () => {
             expect(shape_1.y).toBe(100);
             expect(shape_1.width).toBe(600);
             expect(shape_1.height).toBe(550);
+        });
+
+    });
+
+    describe('Behavior', () => {
+        let eventBus;
+
+        beforeEach(() => eventBus = diagram.get('eventBus'));
+
+        it('should init the resize with one element', () => {
+            eventBus.fire('resize.element.init', {
+                element: { x: 50, y: 100 }
+            });
+
+            expect(resize.position.x).toBe(50);
+            expect(resize.position.y).toBe(100);
         });
 
     });

--- a/test/features/resize/Resize.spec.js
+++ b/test/features/resize/Resize.spec.js
@@ -1,0 +1,44 @@
+import ResizeModule from '../../../src/features/resize';
+import { Tester } from '../../Tester';
+
+
+describe('modules/resize - Resize', () => {
+    let diagram;
+    let shape_1; let shape_2;
+    let resize;
+
+    beforeEach(() => diagram = new Tester({ modules: [ ResizeModule ] }));
+
+    beforeEach(() => resize = diagram.get('resize'));
+
+    beforeEach(() => diagram.invoke(function (canvas, elementFactory) {
+        shape_1 = elementFactory.createShape({
+            id: 'shape_1', x: 100, y: 200, width: 300, height: 400,
+        });
+        shape_2 = elementFactory.createShape({
+            id: 'shape_2', x: 500, y: 200, width: 300, height: 400,
+        });
+
+        canvas.addShape(shape_1);
+        canvas.addShape(shape_2);
+    }));
+
+    it('should be defined', () => {
+        expect(resize).toBeDefined();
+    });
+
+
+    describe('Provider', () => {
+
+        it('should resize a shape', () => {
+            resize.element(shape_1).dimension(50, 100, 600, 550);
+
+            expect(shape_1.x).toBe(50);
+            expect(shape_1.y).toBe(100);
+            expect(shape_1.width).toBe(600);
+            expect(shape_1.height).toBe(550);
+        });
+
+    });
+
+});

--- a/test/features/selection/Selection.spec.js
+++ b/test/features/selection/Selection.spec.js
@@ -9,11 +9,15 @@ describe('modules/selection - Selection', () => {
     let shape1;
     let shape2;
     let selection;
+    let selectionHandles;
     let canvas;
 
     beforeEach(() => diagram = new Tester({ modules: [ SelectionModule ] }));
 
-    beforeEach(() => selection = diagram.get('selection'));
+    beforeEach(() => {
+        selection = diagram.get('selection');
+        selectionHandles = diagram.get('selectionHandles');
+    });
 
     beforeEach(() => canvas = diagram.get('canvas'));
 
@@ -31,6 +35,7 @@ describe('modules/selection - Selection', () => {
 
     it('should be defined', () => {
         expect(selection).toBeDefined();
+        expect(selectionHandles).toBeDefined();
     });
 
     describe('Provider', () => {
@@ -66,6 +71,24 @@ describe('modules/selection - Selection', () => {
 
             expect(selection.count()).toBe(0);
         });
+
+        it('should show handles', function () {
+            selection.select(shape1);
+
+            selectionHandles.handles.forEach((handle) => {
+                expect(handle.visible).toBeTruthy();
+            });
+        });
+
+        it('should hide handles on clear', function () {
+            selection.select(shape1);
+            selection.clear();
+
+            selectionHandles.handles.forEach((handle) => {
+                expect(handle.visible).toBeFalsy();
+            });
+        });
+
     });
 
     describe('Behavior', () => {


### PR DESCRIPTION
Closes #31 
Closes #92

## Describe your changes
- Used the pointer tool mouseevents to handle resize
- Implemented behavior in Resize
- Ensure cursor stays correct
- Ensure it not resize less than its min-width
- Selection handles now match the bbox border

## Screenshots
![resize-se](https://user-images.githubusercontent.com/5788010/56433843-a6a50e80-62d2-11e9-95a1-a47c12caf727.gif)

## Open issues
- Since it seemed complicated to implement the other direction I left it out. This should be fixed in another issue. 
For this there maybe has to be some memorize of the current object dimension.
Also it could be posible to not resize the element directly and use a Preview first and resize it later with a command.
- Usage of a command should also ensure the change history for the comming undo process.
