### PR TITLE
Select all

### DIFF
--- a/src/core/ElementRegistry.js
+++ b/src/core/ElementRegistry.js
@@ -1,0 +1,18 @@
+import BaseElementRegistry from 'diagram-js/lib/core/ElementRegistry';
+
+
+export class ElementRegistry extends BaseElementRegistry {
+
+    constructor (props) {
+        super(props);
+    }
+
+    /**
+     * TODO: Remove hotfix for handles
+     * @return {*}[]
+     */
+    getAll () {
+        return super.getAll().filter((element) => element.type !== 'handle');
+    }
+
+}

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -1,4 +1,4 @@
-import ElementRegistry from 'diagram-js/lib/core/ElementRegistry';
+import { ElementRegistry } from './ElementRegistry';
 import { Canvas } from './Canvas';
 import EventBusModule from './eventBus';
 import CommandStackModule from './command';

--- a/src/features/selection/behaviors/SelectAllBehavior.js
+++ b/src/features/selection/behaviors/SelectAllBehavior.js
@@ -1,0 +1,15 @@
+import { Behavior } from '../../../core/eventBus/Behavior';
+
+
+export class SelectAllBehavior extends Behavior {
+
+    constructor (selection) {
+        super();
+        this.selection = selection;
+    }
+
+    during (event) {
+        this.selection.selectAll();
+    }
+
+}

--- a/src/features/selection/index.js
+++ b/src/features/selection/index.js
@@ -1,6 +1,7 @@
 import OutlineModule from 'diagram-js/lib/features/outline';
 import HandleModule from '../handle';
 import OrientationModule from '../orientation';
+import { SelectAllBehavior } from './behaviors/SelectAllBehavior';
 import { SelectedBehavior } from './behaviors/SelectedBehavior';
 import { SelectionAddBehavior } from './behaviors/SelectionAddBehavior';
 import { SelectionClearBehavior } from './behaviors/SelectionClearBehavior';
@@ -21,6 +22,7 @@ export default {
         'selection',
     ],
     __behaviors__: [
+        [ 'select.all', SelectAllBehavior ],
         [ 'selection.changed', SelectedBehavior ],
         [ 'selection.clear', SelectionClearBehavior ],
         [ 'selection.add', SelectionAddBehavior ],

--- a/src/features/selection/providers/SelectionProvider.js
+++ b/src/features/selection/providers/SelectionProvider.js
@@ -4,13 +4,18 @@ import { getBBox } from 'diagram-js/lib/util/Elements';
 
 export class SelectionProvider extends Selection {
 
-    constructor (eventBus, selectionHandles) {
+    constructor (eventBus, selectionHandles, elementRegistry) {
         super(eventBus);
         this.eventBus = eventBus;
         this.selectionHandles = selectionHandles;
+        this.elementRegistry = elementRegistry;
         this.bbox = {};
 
         this.selectionHandles.create(this.bbox);
+    }
+
+    selectAll () {
+        this.add(this.elementRegistry.getAll());
     }
 
     clear () {

--- a/test/features/selection/Selection.spec.js
+++ b/test/features/selection/Selection.spec.js
@@ -89,6 +89,16 @@ describe('modules/selection - Selection', () => {
             });
         });
 
+        it('should select all elements', function () {
+            expect(selection.count()).toBe(0);
+
+            selection.selectAll();
+
+            const count = canvas._elementRegistry.getAll().length;
+
+            expect(selection.count()).toBe(count - 1);
+        });
+
     });
 
     describe('Behavior', () => {
@@ -115,6 +125,17 @@ describe('modules/selection - Selection', () => {
 
             expect(selection.count()).toBe(2);
         });
+
+        it('should select all elements on select.all', function () {
+            expect(selection.count()).toBe(0);
+
+            eventBus.fire('select.all');
+
+            const count = canvas._elementRegistry.getAll().length;
+
+            expect(selection.count()).toBe(count - 1);
+        });
+
     });
 
     describe('Tools', () => {


### PR DESCRIPTION
Closes #105 

## Describe your changes
- Extended selection provider by a `selectAll` method and the element registery
- Added a `select.all` behavio
- Added a test for to check if all elements got selected
- Removed handles from the `getAll` method of the `elementRegistry`

