### PR TITLE
Fix svg export

### DIFF
--- a/src/core/Canvas.js
+++ b/src/core/Canvas.js
@@ -11,17 +11,25 @@ export class Canvas extends BaseCanvas {
 
     constructor (config, eventBus, graphicsFactory, elementRegistry) {
         super(config, eventBus, graphicsFactory, elementRegistry);
-        this.createUiGroup();
+        this._uiGroup = this.createUiGroup();
+        this._defs = this.createDefs();
     }
 
-    getCurrentScale () {
-        return +this._viewport.getCTM().a.toFixed(5);
+    createDefs () {
+        const defs = create('defs');
+        append(this._svg, defs);
+        return defs;
     }
 
     createUiGroup () {
         const group = create('g');
         classes(group).add('ui');
         append(this._svg, group);
+        return group;
+    }
+
+    getCurrentScale () {
+        return +this._viewport.getCTM().a.toFixed(5);
     }
 
     addShape (shape, parent, parentIndex) {

--- a/src/draw/Renderer.js
+++ b/src/draw/Renderer.js
@@ -1,7 +1,6 @@
 import BaseRenderer from 'diagram-js/lib/draw/BaseRenderer';
 import { create, attr, append, innerSVG } from 'tiny-svg';
 import { stringify } from 'svgson';
-import { query } from 'min-dom'; // TODO: install min dom
 
 
 export class Renderer extends BaseRenderer {
@@ -15,12 +14,6 @@ export class Renderer extends BaseRenderer {
     registerMarker (event) {
         const metaModel = event.plugin.getMetaModel();
         const stylesheet = event.plugin.getStylesheet();
-
-        let defs = query('defs', this.canvas._svg);
-        if (!defs) {
-            defs = create('defs');
-            append(this.canvas._svg, defs);
-        }
 
         metaModel.arrowHeads.forEach((arrowHead) => {
             const style = stylesheet.styles[arrowHead.type];
@@ -36,7 +29,7 @@ export class Renderer extends BaseRenderer {
                 markerHeight: 10,
                 orient: 'auto',
             });
-            append(defs, marker);
+            append(this.canvas._defs, marker);
         });
     }
 

--- a/src/features/export/providers/Exporter.js
+++ b/src/features/export/providers/Exporter.js
@@ -30,7 +30,13 @@ export class Exporter {
     getGraphics () {
         const rootElement = this.canvas.getRootElement();
         const graphicsElement = this.elementRegistry.getGraphics(rootElement);
-        return graphicsElement.cloneNode(true);
+
+        const ns = 'http://www.w3.org/2000/svg';
+        const doc = document.createElementNS(ns, 'svg');
+        doc.appendChild(graphicsElement.cloneNode(true));
+        doc.appendChild(this.canvas._defs.cloneNode(true));
+
+        return doc;
     }
 
 }

--- a/src/features/export/providers/SVGSerializer.js
+++ b/src/features/export/providers/SVGSerializer.js
@@ -5,13 +5,7 @@ export class SVGSerializer {
     }
 
     serialize (data) {
-        const ns = 'http://www.w3.org/2000/svg';
-        // const doc = document.implementation.createDocument(ns, 'svg', null);
-        // doc.documentElement.appendChild(data);
-        const doc = document.createElementNS(ns, 'svg');
-        doc.appendChild(data);
-
-        const payload = this.xmlSerializer.serializeToString(doc);
+        const payload = this.xmlSerializer.serializeToString(data);
 
         const mimeType = 'image/svg+xml';
         const fileExtension = '.svg';


### PR DESCRIPTION
Closes #110 

## Describe your changes

- Added a properties with references to defs to the Canvas
- Refactored Exporter.getGraphics() to return a complete and valid SVG