### PR TITLE
Assign 'Noto Sans' font to SVG text elements

### DIFF
--- a/src/draw/TextRenderer.js
+++ b/src/draw/TextRenderer.js
@@ -1,5 +1,5 @@
 import BaseRenderer from 'diagram-js/lib/draw/BaseRenderer';
-import { append, classes } from 'tiny-svg';
+import { append, classes, create, innerSVG, attr } from 'tiny-svg';
 import TextUtils from 'diagram-js/lib/util/Text';
 
 
@@ -9,6 +9,14 @@ export class TextRenderer extends BaseRenderer {
         super(eventBus, 10);
         this.canvas = canvas;
         this.textUtils = new TextUtils();
+        this.addFont();
+    }
+
+    addFont () {
+        const fontStyle = create('style', { type: 'text/css' });
+        innerSVG(fontStyle, '@import url(\'https://fonts.googleapis.com/css?' +
+            'family=Noto+Sans:400,400i,700,700i|Source+Code+Pro:400,600\');');
+        append(this.canvas._defs, fontStyle);
     }
 
     canRender (element) {
@@ -18,6 +26,7 @@ export class TextRenderer extends BaseRenderer {
     drawShape (graphics, element) {
         const options = element.options || { };
         const text = this.textUtils.createText(element.text, options);
+        attr(text, { 'font-family': '\'Noto Sans\', sans-serif' });
         classes(text).add('djs-label');
         append(graphics, text);
         return text;


### PR DESCRIPTION
Closes #103 

## Describe your changes
- Add style tag with google fonts url
- Assign 'Noto Sans' to fonts directly

