### PR TITLE
Use create shape to import labels

### DIFF
--- a/src/features/import/providers/Importer.js
+++ b/src/features/import/providers/Importer.js
@@ -52,7 +52,7 @@ export class Importer {
     }
 
     createLabel (element) {
-        // TODO
+        this.createShape(element);
     }
 
 }


### PR DESCRIPTION
Closes #90 

## Describe your changes
- As diagram-js doesn't differentiate labels from shapes I used the createShape method to import labels