### PR TITLE
Restructure labels -> targets in metamodel

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "diagram-js-origin": "^1.2.0",
     "didi": "^4.0.0",
     "lodash": "^4.17.11",
-    "renew-formalism": "^1.0.0",
+    "renew-formalism": "^1.0.1",
     "svgson": "^3.0.0",
     "tiny-svg": "^2.2.1"
   },

--- a/test/util/TestPlugin.js
+++ b/test/util/TestPlugin.js
@@ -14,17 +14,24 @@ export class TestPlugin extends Formalism.Plugin {
             classifiers: [
                 {
                     type: 'classifier_1',
-                    labels: [ 'label_1' ],
                 },
                 {
                     type: 'classifier_2',
-                    labels: [ 'label_1' ],
                 },
             ],
             relations: [
                 {
                     type: 'relation_1',
-                    labels: [ 'label_1' ],
+                },
+            ],
+            texts: [
+                {
+                    type: 'label_1',
+                    targets: [
+                        'classifier_1',
+                        'classifier_2',
+                        'relation_1',
+                    ],
                 },
             ],
         });


### PR DESCRIPTION
Closes #116 

## Changes
- Changed syntax in metamodel, so that texts are defining its targets