### PR TITLE
Fire resize.element after createShape

### DIFF
--- a/src/core/Canvas.js
+++ b/src/core/Canvas.js
@@ -11,6 +11,7 @@ export class Canvas extends BaseCanvas {
 
     constructor (config, eventBus, graphicsFactory, elementRegistry) {
         super(config, eventBus, graphicsFactory, elementRegistry);
+        this.eventBus = eventBus;
         this._uiGroup = this.createUiGroup();
         this._defs = this.createDefs();
     }
@@ -32,8 +33,12 @@ export class Canvas extends BaseCanvas {
         return +this._viewport.getCTM().a.toFixed(5);
     }
 
-    addShape (shape, parent, parentIndex) {
-        return super.addShape(shape, parent, parentIndex);
+    addShape (element, parent, parentIndex) {
+        const shape = super.addShape(element, parent, parentIndex);
+        if (element.type === 'shape') {
+            this.eventBus.fire('resize.element', { element });
+        }
+        return shape;
     }
 
     addUiElement (type, element) {

--- a/src/features/resize/behaviors/ResizeElementBehavior.js
+++ b/src/features/resize/behaviors/ResizeElementBehavior.js
@@ -27,6 +27,11 @@ export class ResizeElementBehavior extends Behavior {
 
     after (event) {
         const element = event.element || event.elements[0];
+
+        if (!element.metaObject) {
+            return;
+        }
+
         const shape = element.metaObject;
 
         const bounds = element;


### PR DESCRIPTION
Closes #134 

## Describe your changes
- Fired a `'resize.element'` event on each addShape, this should handle all imported shapes and non default initializations

## Note 
It will not resize if the resize module is not loaded. The canvas module does not depend on resize.
