### PR TITLE
Layout incoming and outgoing connections after resize

### DIFF
--- a/src/features/resize/behaviors/ResizeElementBehavior.js
+++ b/src/features/resize/behaviors/ResizeElementBehavior.js
@@ -3,12 +3,13 @@ import { Behavior } from '../../../core/eventBus/Behavior';
 
 export class ResizeElementBehavior extends Behavior {
 
-    constructor (eventBus, resize, elementRegistry, graphicsFactory) {
+    constructor (eventBus, resize, elementRegistry, graphicsFactory, layouter) {
         super();
         this.eventBus = eventBus;
         this.resize = resize;
         this.elementRegistry = elementRegistry;
         this.graphicsFactory = graphicsFactory;
+        this.layouter = layouter;
     }
 
     init (event) {
@@ -78,6 +79,8 @@ export class ResizeElementBehavior extends Behavior {
         }
 
         this._updateGraphics(element, 'shape');
+        element.incoming.forEach(this._layoutConnection.bind(this));
+        element.outgoing.forEach(this._layoutConnection.bind(this));
     }
 
     _updateGraphics (element, type) {
@@ -88,6 +91,11 @@ export class ResizeElementBehavior extends Behavior {
         this.eventBus.fire(element.type + '.changed', event);
         this.eventBus.fire('elements.changed', event);
         this.eventBus.fire('element.changed', event);
+    }
+
+    _layoutConnection (connection) {
+        connection.waypoints = this.layouter.layoutConnection(connection);
+        this._updateGraphics(connection);
     }
 
 }

--- a/src/features/resize/index.js
+++ b/src/features/resize/index.js
@@ -3,9 +3,11 @@ import { ResizeElementCommand } from './commands/ResizeElementCommand';
 import { ResizeProvider } from './providers/ResizeProvider';
 import { ResizeElementRule } from './rules/ResizeElementRule';
 
+import LayouterModule from '../layouter';
 
 export default {
     __depends__: [
+        LayouterModule,
     ],
     __init__: [
         'resize',


### PR DESCRIPTION
Closes #133

## Describe your changes
- Use the layouter to layout the incoming and outgoing labels after resize
